### PR TITLE
Labs 3 - Multiple API instances behind an Nginx reverse-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ Or build and run with a single command:
 ```
 docker-compose up --build
 ```
+
+#### Tips and Tricks
+
+Windows users may encounter some problems because of the following difference:
+
+- Windows ends lines in a carriage return and a linefeed \r\n,
+- While Linux and macOS only use a linefeed \n.
+
+To fix the problem, before git clone or git pull, run the following cmd:
+```
+git config --global core.autocrlf input
+```
+
+[ref.](https://github.com/docker/compose/issues/2301)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,6 @@ services:
             DB_USER: postgres
             DB_PASSWORD: postgres
             DB_NAME: soaapidb
-        ports:
-            - 8080:8000
         depends_on:
             postgres-db:
                 condition: service_healthy
@@ -38,6 +36,28 @@ services:
             interval: 10s
             timeout: 5s
             retries: 5
+        deploy:
+            mode: replicated
+            replicas: 5
+
+    nginx-proxy:
+        build:
+            context: ./nginx
+            dockerfile: Dockerfile
+        # name for the image built with ./nginx/Dockerfile
+        image: nginx-server-image
+        # custom container name for the proxy container
+        container_name: items-api-nginx-proxy
+        ports:
+            - 5002:5000
+        environment:
+            NGINX_SERVER_PORT: 5000
+            API_HOST: items-api
+            API_PORT: 8000
+        depends_on:
+            items-api:
+                condition: service_healthy
+
 
 volumes:
     db-data:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,24 @@
+FROM nginx:1.17.6
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils jq
+
+# Remove default Nginx config
+RUN rm /etc/nginx/nginx.conf
+
+# Copy the modified Nginx conf
+COPY nginx.conf /etc/nginx
+
+# Copy proxy config template file
+COPY api_nginx.conf /api_nginx.conf.template
+
+# Create proxy def file
+RUN mkdir /etc/nginx/sites-enabled
+RUN touch /etc/nginx/sites-enabled/api_nginx.conf
+
+# Copy the custom setup and entrypoint scripts
+COPY serve.sh /serve.sh
+COPY env_setup.sh /env_setup.sh
+
+ENTRYPOINT ["/serve.sh"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17.6
+FROM nginx:1.23.3
 
 # Remove default Nginx config
 RUN rm /etc/nginx/nginx.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,9 +1,5 @@
 FROM nginx:1.17.6
 
-RUN set -x \
-    && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils jq
-
 # Remove default Nginx config
 RUN rm /etc/nginx/nginx.conf
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -15,6 +15,5 @@ RUN touch /etc/nginx/sites-enabled/api_nginx.conf
 
 # Copy the custom setup and entrypoint scripts
 COPY serve.sh /serve.sh
-COPY env_setup.sh /env_setup.sh
 
-ENTRYPOINT ["/serve.sh"]
+ENTRYPOINT ["/bin/bash", "/serve.sh"]

--- a/nginx/api_nginx.conf
+++ b/nginx/api_nginx.conf
@@ -6,7 +6,7 @@ server {
     # Define the specified charset to the “Content-Type” response header field
     charset utf-8;
 
-    # Configure NGINX to reverse proxy HTTP requests to the upstream server (uWSGI server)
+    # Configure NGINX to reverse proxy HTTP requests to the upstream server (uvicorn)
     location / {
         # Define the location of the proxy server to send the request to
         proxy_pass http://${API_HOST}:${API_PORT};

--- a/nginx/api_nginx.conf
+++ b/nginx/api_nginx.conf
@@ -1,0 +1,25 @@
+# Define the parameters for a specific virtual host/server
+server {
+    # Define the server name, IP address, and/or port of the server
+    listen ${NGINX_SERVER_PORT};
+    server_name  localhost;
+    # Define the specified charset to the “Content-Type” response header field
+    charset utf-8;
+
+    # Configure NGINX to reverse proxy HTTP requests to the upstream server (uWSGI server)
+    location / {
+        # Define the location of the proxy server to send the request to
+        proxy_pass http://${API_HOST}:${API_PORT};
+
+        # Redefine the header fields that NGINX sends to the upstream server
+        # proxy_set_header Host $host;
+        # proxy_set_header X-Real-IP $remote_addr;
+        # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /static-files/manifest.json {
+        # Basic auth off for /static-files/manifest.json
+        auth_basic "off";
+        proxy_pass http://${API_HOST}:${API_PORT};
+    }
+}

--- a/nginx/api_nginx.conf
+++ b/nginx/api_nginx.conf
@@ -17,9 +17,4 @@ server {
         # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    location /static-files/manifest.json {
-        # Basic auth off for /static-files/manifest.json
-        auth_basic "off";
-        proxy_pass http://${API_HOST}:${API_PORT};
-    }
 }

--- a/nginx/env_setup.sh
+++ b/nginx/env_setup.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-envsubst < /api_nginx.conf.template > /etc/nginx/sites-enabled/api_nginx.conf

--- a/nginx/env_setup.sh
+++ b/nginx/env_setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+envsubst < /api_nginx.conf.template > /etc/nginx/sites-enabled/api_nginx.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,49 @@
+# Define the user that will own and run the Nginx server
+user  nginx;
+# Define the number of worker processes; recommended value is the number of
+# cores that are being used by your server
+worker_processes  1;
+
+# Define the location on the file system of the error log, plus the minimum
+# severity to log messages for
+error_log  /var/log/nginx/error.log warn;
+# Define the file that will store the process ID of the main NGINX process
+pid        /var/run/nginx.pid;
+
+
+# events block defines the parameters that affect connection processing.
+events {
+    # Define the maximum number of simultaneous connections that can be opened by a worker process
+    worker_connections  1024;
+}
+
+
+# http block defines the parameters for how NGINX should handle HTTP web traffic
+http {
+    # Include the file defining the list of file types that are supported by NGINX
+    include       /etc/nginx/mime.types;
+    # Define the default file type that is returned to the user
+    default_type  text/html;
+
+    # Define the format of log messages.
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    # Define the location of the log of access attempts to NGINX
+    access_log  /var/log/nginx/access.log  main;
+
+    # Define the parameters to optimize the delivery of static content
+    sendfile        on;
+    tcp_nopush     on;
+    tcp_nodelay    on;
+
+    # Define the timeout value for keep-alive connections with the client
+    keepalive_timeout  65;
+
+    # Define the usage of the gzip compression algorithm to reduce the amount of data to transmit
+    #gzip  on;
+
+    # Include additional parameters for virtual host(s)/server(s)
+    include /etc/nginx/sites-enabled/*.conf;
+}

--- a/nginx/serve.sh
+++ b/nginx/serve.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+echo "Setting up nginx environment ..."
+./env_setup.sh
+
+echo "Starting nginx server ..."
+exec nginx -g "daemon off;"

--- a/nginx/serve.sh
+++ b/nginx/serve.sh
@@ -3,5 +3,6 @@
 
 echo "Setting up nginx environment ..."
 envsubst < /api_nginx.conf.template > /etc/nginx/sites-enabled/api_nginx.conf
+
 echo "Starting nginx server ..."
 exec nginx -g "daemon off;"

--- a/nginx/serve.sh
+++ b/nginx/serve.sh
@@ -2,7 +2,7 @@
 
 
 echo "Setting up nginx environment ..."
-./env_setup.sh
+envsubst < /api_nginx.conf.template > /etc/nginx/sites-enabled/api_nginx.conf
 
 echo "Starting nginx server ..."
 exec nginx -g "daemon off;"

--- a/nginx/serve.sh
+++ b/nginx/serve.sh
@@ -3,6 +3,5 @@
 
 echo "Setting up nginx environment ..."
 envsubst < /api_nginx.conf.template > /etc/nginx/sites-enabled/api_nginx.conf
-
 echo "Starting nginx server ..."
 exec nginx -g "daemon off;"

--- a/src/api/probes_api.py
+++ b/src/api/probes_api.py
@@ -1,3 +1,4 @@
+import socket
 from fastapi import APIRouter
 
 
@@ -6,5 +7,6 @@ router = APIRouter(tags=["probes"])
 
 @router.get("/healthcheck")
 def healthcheck_probe():
-    return {"status": "ok"}
+    ip_address = socket.gethostbyname(socket.gethostname())
+    return {"status": f"ok from {ip_address}"}
 


### PR DESCRIPTION
- Update the healthcheck probe endpoint to return the host's (container) IP address
- Add Nginx reverse-proxy configs
- Setup replication mode with 5 instances for the Items API
- Nginx configured to forward requests to the 5 API instances (load balancing, round-robin is the default strategy)
- - - 
From:
![soa-Labs drawio](https://user-images.githubusercontent.com/23142928/226428718-e5a0f7d8-c979-4427-91bc-14e94d554c81.png)
- - -
To:
![soa-Labs drawio (5)](https://user-images.githubusercontent.com/23142928/226428770-64514828-d0c8-44e9-addb-3734ac0ba197.png)
- - -